### PR TITLE
Compatibility for Python3 (continues to support Python2)

### DIFF
--- a/scripts/AugumentBrownClusteringFeature46.py
+++ b/scripts/AugumentBrownClusteringFeature46.py
@@ -31,11 +31,11 @@ import sys
 import codecs
 
 def usage():
-    print "Usage: AugumentBrownClusteringFeature.py [Brown_Clustering_Dictionary] " \
-          "[Input_Conll_File] [Y/N(case-sensitive)] > [Output_file]"
-    print "Example: AugumentBrownClusteringFeature.py paths input.txt > output.txt"
-    print "The program will add two kind of Strings at the end, the first one is the first 4 " \
-          "bit of the Brown Cluster label and the second one is the whole Brown Cluster label."
+    print("Usage: AugumentBrownClusteringFeature.py [Brown_Clustering_Dictionary] " \
+          "[Input_Conll_File] [Y/N(case-sensitive)] > [Output_file]")
+    print("Example: AugumentBrownClusteringFeature.py paths input.txt > output.txt")
+    print("The program will add two kind of Strings at the end, the first one is the first 4 " \
+          "bit of the Brown Cluster label and the second one is the whole Brown Cluster label.")
 
 
 if __name__ == "__main__":
@@ -63,7 +63,7 @@ if __name__ == "__main__":
             sys.stdout.write("\n")
             continue
         cvlist = line.split("\t")
-	if sys.argv[3] == "N":
+        if sys.argv[3] == "N":
             brown = brown_dict.get(cvlist[1].lower().strip(), 'OOV')
         else:
             brown = brown_dict.get(cvlist[1].strip(), 'OOV')
@@ -76,4 +76,4 @@ if __name__ == "__main__":
         for ele in cvlist:
             tline = tline + ele + "\t"
         tline = tline[:len(tline) - 1]
-        print tline
+        print(tline)

--- a/scripts/ConvertFromTaggingResToConll.py
+++ b/scripts/ConvertFromTaggingResToConll.py
@@ -21,6 +21,7 @@ import codecs
 import os
 import re
 import sys
+import io
 
 parser = argparse.ArgumentParser(description='')
 parser.add_argument('inputf', type=str, metavar='', help='')
@@ -46,12 +47,12 @@ def read_corpus(filename):
 
 def print_sentence(sentence, outputf):
     for line in sentence:
-        s = u""
+        s = u""                 #unicode for Python2
         for field in line:
-            s += field + u"\t"
-        s = s.strip()
-        outputf.write(s+u"\n")
-    outputf.write(u"\n")
+            s += field + "\t"   #Python2: unicode + str return unicode
+        s = s.strip()           #Python2: Still unicode
+        outputf.write(s+"\n")   #Python2: Still unicode
+    outputf.write("\n")
     return
 
 def convert_sentence(sen):
@@ -66,7 +67,8 @@ def convert_sentence(sen):
     return new_sen 
 
 if __name__ == '__main__':
-    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+    #sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+    sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding='UTF-8', line_buffering=True)   #Ref: https://wiki.python.org/moin/PortingToPy3k/BilingualQuickRef#codecs
     corpus = read_corpus(A.inputf)
 
     conll_format_corpus = []

--- a/token_selection/features.py
+++ b/token_selection/features.py
@@ -119,6 +119,6 @@ def get_all(trainfile):
 
 if __name__ == "__main__":
     sentset, labelset, postagseqs, vecs1, vecs2, all_feats = get_all(sys.argv[1])
-    print sentset[25]
-    print labelset[25]
-    print len(all_feats)
+    print(sentset[25])
+    print(labelset[25])
+    print(len(all_feats))

--- a/token_selection/pipeline.py
+++ b/token_selection/pipeline.py
@@ -30,7 +30,7 @@ def print_line_withmodification(cline, tag):
     for i in xrange(0,13):
         s += (cline[i] + "\t")
     s += tag
-    print s
+    print(s)
 
 
 def main(testfile, featsfile):


### PR DESCRIPTION
Other than the simple print statement to function conversion, using io.TextIOWrapper for unicode should take care of making this work for both Python 2 and 3 (Ref: https://wiki.python.org/moin/PortingToPy3k/BilingualQuickRef#codecs)
